### PR TITLE
Feat/approver role

### DIFF
--- a/views/layout.jade
+++ b/views/layout.jade
@@ -142,6 +142,11 @@ html
                                         a(href='/admin/verifications') Pending Verifications
                                     li
                                         a(href='/admin/health') System Health
+                                else if authUser.approver
+                                    li(role='separator' class='divider')
+                                    li
+                                      a(href='/admin/approvals') Pending Approvals
+
 
     block content
 

--- a/views/user.jade
+++ b/views/user.jade
@@ -22,7 +22,7 @@ block scripts
                 if (password != password2)
                     password2Error = 'Passwords do not match.';
             }
-                
+
             try {
                 $('#errorFirstname').text(firstnameError);
                 $('#errorLastname').text(lastnameError);
@@ -32,16 +32,16 @@ block scripts
                 alert('Validation errored! Check your input values.');
                 return false;
             }
-            
-            var somethingBad = 
+
+            var somethingBad =
                 !!firstnameError
                 || !!lastnameError
                 || !!passwordError
                 || !!password2Error;
-                
+
             return !somethingBad;
         }
-        
+
         function setAction(thisAction) {
             $('#__action').val(thisAction);
         }
@@ -56,21 +56,21 @@ block content
     .jumbotron.wicked-admin-title
         .container.wicked-title-container
             h1= userInfo.name
-            
+
             p Review and edit user information.
-            
+
     .container.wicked-container
-    
+
         br
         br
         form(role='form' action='/users/#{userInfo.id}' method='post' onsubmit='return verifyContent()')
-        
+
             input(type='hidden' name='__action' id='__action' value='none')
-            
+
             .form-group
                 label(for='firstname') First name:
                 input(id='firstname' name='firstname' value='#{userInfo.firstName}').form-control
-                small 
+                small
                     span(id='errorFirstname' style='color:red')
             .form-group
                 label(for='lastname') Last name:
@@ -96,7 +96,7 @@ block content
                             table(width='100%')
                                 tr
                                     td
-                                        h5.panel-title 
+                                        h5.panel-title
                                             a(data-toggle='collapse' href='#collapse') Change/Set Password
                                     td(style='text-align:right')
                                         if userInfo.hasPassword
@@ -149,8 +149,10 @@ block content
                                         small &nbsp;<i>This is the default group for users with a validated email address.</i>
                                     if group.adminGroup
                                         strong &nbsp;Admin group
+                                    if group.approverGroup
+                                            strong &nbsp;Approver group
                 br
-            
+
             if glob.api && glob.api.portal && glob.api.portal.enableApi && authUser.clientId && authUser.clientSecret
                 .panel.panel-default
                     .panel-heading
@@ -191,4 +193,3 @@ block content
                     else
                         form(role='form' action='/users/#{userInfo.id}/delete' onsubmit='return confirmDelete();' method='post')
                             button(type='submit').btn.btn-danger Delete User
-    


### PR DESCRIPTION
## Overview 
The group feature now supports an approval role.  The approver role allows for controlling which users have the ability to approve API subscription requests.  
 
 ## Summary 
Approver role provides flexibility for use of the Wicked API portal across an enterprise, where there may be business or commercial need to segment who has the responsibility to take action on an API approval request. By introducing the approver group type, we are able to control who sees what API approval requests.  

## How it works 

1.  **Configuring Groups to have approval role** 
The Groups Configuration Screen in Kickstarter has a checkbox which allows the user to assign a new group type called 'approver' as part of Group Definition. For example, we create a new group called 'Electric Car API Approver' and assign it as approver 
 _Note: **This change does not impact existing admin group functionality**._ 
![snip20180222_6](https://user-images.githubusercontent.com/9421117/36571212-711816e2-17ea-11e8-853d-318ccb19bb84.png)

2. **Associating APIs to approvers** 
Approver needs to be part of the group that is associated with the API that he/she has the responsibility to approve, enabling the approver to see their approval requests when logging into the Wicked API Portal.  
For example, our gateway has an API, 'Charge Reader'.  To approver needs to be part of the  'Charge Reader' group to see approval requests for this API in the portal.
![snip20180222_7](https://user-images.githubusercontent.com/9421117/36571218-776b7b9c-17ea-11e8-850c-79ebb0f865ac.png)


3. **API Portal UI Changes** 
 The API portal menu for an approver includes a link to 'Pending Approvals' 
![approver3](https://user-images.githubusercontent.com/9421117/36286412-8387c5f6-1264-11e8-83e8-45216cf0fa34.png)

## Full changelog
- Changed `layout.jade` to include "Pending Approvals" menu for approvers
- Changed `users.jade` to display approver group for user 

