### PR TITLE
Swagger UI plugin upgrade 3.13.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "request": "2.74.0",
     "serve-favicon": "2.3.0",
     "session-file-store": "1.0.0",
-    "swagger-ui": "2.1.5",
+    "swagger-ui-dist": "^3.13.6",
     "tmp": "0.0.30",
     "wicked-sdk": "^0.11.3",
     "write-file-atomic": "1.3.1"

--- a/routes/apis.js
+++ b/routes/apis.js
@@ -243,6 +243,7 @@ router.get('/:api', function (req, res, next) {
                 if (subsResults[i]) {
                     thisApp.hasSubscription = true;
                     thisApp.plan = plansMap[subsResults[i].plan];
+                    thisApp.redirectUri = appsResults[i].redirectUri;
                     thisApp.apiKey = subsResults[i].apikey;
                     thisApp.clientId = subsResults[i].clientId;
                     thisApp.clientSecret = subsResults[i].clientSecret;

--- a/views/api.jade
+++ b/views/api.jade
@@ -156,7 +156,9 @@ block content
                                                 if apiInfo.auth == "key-auth"
                                                     a(href='#{glob.network.schema}://#{glob.network.apiHost}/swagger-ui/?apikey=#{app.apiKey}&url=#{app.swaggerLink}' target='_blank').btn.btn-default Try it!
                                                 else if apiInfo.auth == "oauth2" && apiInfo.settings && apiInfo.settings.enable_client_credentials
-                                                    a(href='#{glob.network.schema}://#{glob.network.apiHost}/swagger-ui/?client_id=#{app.clientId}&client_secret=#{app.clientSecret}&url=#{app.swaggerLink}' target='_blank').btn.btn-default Try it!
+                                                    a(href='#{glob.network.schema}://#{glob.network.apiHost}/swagger-ui/?client_id=#{app.clientId}&client_secret=#{app.clientSecret}&url=#{app.swaggerLink}&application=#{app.name}' target='_blank').btn.btn-default Try it!
+                                                else if apiInfo.auth == "oauth2" && app.redirectUri && app.redirectUri.indexOf("swagger-ui/oauth2-redirect.html") > 0
+                                                    a(href='#{glob.network.schema}://#{glob.network.apiHost}/swagger-ui/?client_id=#{app.clientId}&client_secret=#{app.clientSecret}&url=#{app.swaggerLink}&application=#{app.name}&redirect_uri=#{app.redirectUri}' target='_blank').btn.btn-default Try it!
                                                 else
                                                     | ---
                                         else

--- a/views/swagger-ui.jade
+++ b/views/swagger-ui.jade
@@ -2,26 +2,13 @@ html
   head
     title= title
 
-    link(href='css/reset.css' media='screen' rel='stylesheet' type='text/css')
-    link(href='css/screen.css' media='screen' rel='stylesheet' type='text/css')
-    link(href='css/reset.css' media='print' rel='stylesheet' type='text/css')
-    link(href='css/print.css' media='print' rel='stylesheet' type='text/css')
     link(href='css/overrides.css' media='screen' rel='stylesheet' type='text/css')
+    link(href='swagger-ui.css' media='screen' rel='stylesheet' type='text/css')
+    script(src='https://code.jquery.com/jquery-2.2.4.min.js')
+    script(src='https://code.jquery.com/ui/1.12.0/jquery-ui.js')
 
-    script(src='lib/object-assign-pollyfill.js' type='text/javascript')
-    script(src='lib/jquery-1.8.0.min.js' type='text/javascript')
-    script(src='lib/jquery.slideto.min.js' type='text/javascript')
-    script(src='lib/jquery.wiggle.min.js' type='text/javascript')
-    script(src='lib/jquery.ba-bbq.min.js' type='text/javascript')
-    script(src='lib/handlebars-2.0.0.js' type='text/javascript')
-    script(src='lib/lodash.min.js' type='text/javascript')
-    script(src='lib/backbone-min.js' type='text/javascript')
-    script(src='swagger-ui.js' type='text/javascript')
-    script(src='lib/highlight.9.1.0.pack.js' type='text/javascript')
-    script(src='lib/highlight.9.1.0.pack_extended.js' type='text/javascript')
-    script(src='lib/jsoneditor.min.js' type='text/javascript')
-    script(src='lib/marked.js' type='text/javascript')
-    script(src='lib/swagger-oauth.js' type='text/javascript')
+    script(src='swagger-ui-bundle.js' type='text/javascript')
+    script(src='swagger-ui-standalone-preset.js' type='text/javascript')
 
     script(type="text/javascript").
       $(function () {
@@ -47,6 +34,17 @@ html
         else
           client_secret = null;
 
+        var application = window.location.search.match(/application=([^&]+)/);
+        if (application && application.length > 1)
+          application = decodeURIComponent(application[1]);
+        else
+          application = null;
+        var redirect_uri = window.location.search.match(/redirect_uri=([^&]+)/);
+        if (redirect_uri && redirect_uri.length > 1)
+          redirect_uri = decodeURIComponent(redirect_uri[1]);
+        else
+          redirect_uri = null;
+
         var supportedMethods = [];
         if (apikey || client_id)
           supportedMethods = ['get', 'post', 'put', 'delete', 'patch'];
@@ -55,54 +53,40 @@ html
         if(window.SwaggerTranslator) {
           window.SwaggerTranslator.translate();
         }
-        window.swaggerUi = new SwaggerUi({
+        const ui = SwaggerUIBundle({
           url: url,
-          dom_id: "swagger-ui-container",
           supportedSubmitMethods: supportedMethods,
+          dom_id: '#swagger-ui-container',
+          oauth2RedirectUrl: redirect_uri,
+          presets: [
+            SwaggerUIBundle.presets.apis,
+            SwaggerUIBundle.SwaggerUIStandalonePreset
+          ],
           onComplete: function(swaggerApi, swaggerUi){
-            if(typeof initOAuth == "function") {
-              initOAuth({
-                clientId: "your-client-id",
-                clientSecret: "your-client-secret-if-required",
+            if(typeof ui.initOAuth == "function") {
+              ui.initOAuth({
+                clientId: client_id,
+                clientSecret: client_secret,
                 realm: "your-realms",
-                appName: "your-app-name",
+                appName: application,
                 scopeSeparator: ",",
                 additionalQueryStringParams: {}
               });
             }
-
-            if(window.SwaggerTranslator) {
-              window.SwaggerTranslator.translate();
-            }
-
-            $('pre code').each(function(i, e) {
-              hljs.highlightBlock(e)
-            });
-
             if (apikey)
-              $('input[name=#{glob.api.headerName}]').val(apikey);
-            if (client_id) {
-              $('input[name=client_id]').val(client_id);
-              $('input[name=grant_type]').val('client_credentials');
-              $('input[name=Authorization]').val('Bearer ...');
-            }
-            if (client_secret)
-              $('input[name=client_secret]').val(client_secret);
+              ui.preauthorizeApiKey("key", apikey);
             if ("http" == "#{glob.network.schema}")
               $('input[name=x-forwarded-proto]').val('https');
           },
           onFailure: function(data) {
             log("Unable to Load SwaggerUI");
           },
-          docExpansion: "none",
           jsonEditor: false,
           apisSorter: "alpha",
           defaultModelRendering: 'schema',
           showRequestHeaders: false
         });
-
-        window.swaggerUi.load();
-
+        window.swaggerUi = ui;
         function log() {
           if ('console' in window) {
             console.log.apply(console, arguments);


### PR DESCRIPTION
## Changelog
- Upgrade swagger UI plugin to 3.13.6
- Modified `/apis `route to include `redirect_uri`
- Modified `api.jade` view to include "Try it" button by detecting swagger UI plugin redirect uri
- Modified `swagger-ui.jade` to integrate new `SwaggerUIBundle` JS control